### PR TITLE
Add heading ids to rendered markdown

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -11,9 +11,18 @@ import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
 import { HttpClientModule, HttpClient, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { provideAnimations } from '@angular/platform-browser/animations';
-import { MarkdownModule } from 'ngx-markdown';
+import { MarkdownModule, MarkedOptions, MarkedRenderer } from 'ngx-markdown';
 
-import { JwtInterceptor } from './services/jwt.interceptor'; 
+import { JwtInterceptor } from './services/jwt.interceptor';
+
+export function markedOptionsFactory(): MarkedOptions {
+  const renderer = new MarkedRenderer();
+  renderer.heading = (text: string, level: number, raw: string, slugger) => {
+    const slug = slugger.slug(text);
+    return `<h${level} id="${slug}">${text}</h${level}>`;
+  };
+  return { renderer } as MarkedOptions;
+}
 
 export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
   return new TranslateHttpLoader(http, 'assets/i18n/', '.json');
@@ -30,7 +39,12 @@ export const appConfig: ApplicationConfig = {
       multi: true,
     },
     importProvidersFrom(
-      MarkdownModule.forRoot(),
+      MarkdownModule.forRoot({
+        markedOptions: {
+          provide: MarkedOptions,
+          useFactory: markedOptionsFactory,
+        },
+      }),
       HttpClientModule,
       TranslateModule.forRoot({
         defaultLanguage: 'fr',

--- a/src/app/pages/project/project.component.ts
+++ b/src/app/pages/project/project.component.ts
@@ -29,6 +29,19 @@ export class ProjectComponent implements OnInit, OnDestroy  {
   isLoading = true;
   currentLang = 'fr';
 
+  private slugCounts: Record<string, number> = {};
+
+  private slugify(text: string): string {
+    let slug = text.toLowerCase().trim().replace(/[^\w]+/g, '-');
+    if (this.slugCounts[slug] !== undefined) {
+      const count = ++this.slugCounts[slug];
+      slug = `${slug}-${count}`;
+    } else {
+      this.slugCounts[slug] = 0;
+    }
+    return slug;
+  }
+
 
   private projectService = inject(ProjectService);
   private route = inject(ActivatedRoute);
@@ -85,10 +98,11 @@ export class ProjectComponent implements OnInit, OnDestroy  {
   private buildToc(markdown: string) {
     const regex = /^(#{2,6})\s+(.*)$/gm;
     let match: RegExpExecArray | null;
+    this.slugCounts = {};
     while ((match = regex.exec(markdown))) {
       const level = match[1].length;
       const text = match[2].trim();
-      const slug = text.toLowerCase().replace(/[^\w]+/g, '-');
+      const slug = this.slugify(text);
       this.toc.push({ level, text, slug });
     }
   }


### PR DESCRIPTION
## Summary
- configure ngx-markdown to generate `id` attributes for headings
- keep table of contents slugs in sync with unique slug generation

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff0328550832793850bacc4891d38