### PR TITLE
Disable Markdown sanitization

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,4 @@
-import { ApplicationConfig, importProvidersFrom } from '@angular/core';
+import { ApplicationConfig, importProvidersFrom, SecurityContext } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import {
   provideHttpClient,
@@ -61,9 +61,9 @@ export const appConfig: ApplicationConfig = {
     },
     importProvidersFrom(
       MarkdownModule.forRoot({
+        sanitize: SecurityContext.NONE,
         markedOptions: {
           provide: MARKED_OPTIONS,
-
           useFactory: markedOptionsFactory,
         },
       }),


### PR DESCRIPTION
## Summary
- disable sanitization in the Markdown module so custom IDs on headings survive

## Testing
- `npm test -- --watch=false` *(fails: `auth.guard` etc. not exported)*

------
https://chatgpt.com/codex/tasks/task_e_686041269a408327bfe25cf752ffe6f9